### PR TITLE
Use cl-lib instead of cl

### DIFF
--- a/list-utils.el
+++ b/list-utils.el
@@ -256,7 +256,7 @@ A hash-table-test is defined with the same name."
 
 ;;;###autoload
 (progn
-  (require 'cl)
+  (require 'cl-lib)
   (cl-defstruct tconc head tail))
 
 ;;;###autoload


### PR DESCRIPTION
Hi again! It seems to me that no cl functions without the cl- prefix are used, and that this change is safe to make. At least flycheck doesn't complain about any undefined functions.